### PR TITLE
Add support for Python 2.6

### DIFF
--- a/ehrcorral/ehrcorral.py
+++ b/ehrcorral/ehrcorral.py
@@ -61,7 +61,7 @@ def compress(names, method):
         A list of the compressions.
     """
     if not isinstance(names, list):
-        ValueError("Expected a list of names, got a {}.".format(type(names)))
+        ValueError("Expected a list of names, got a {0}.".format(type(names)))
     compressions = []
     raw_compressions = map(method, names)
     # Double metaphone returns a list of tuples, so need to unpack it
@@ -265,7 +265,7 @@ class Herd(object):
         if population is None:
             return str(())
         elif len(population) >= 4:
-            return "({},\n {}\n ...,\n {},\n {})".format(
+            return "({0},\n {1}\n ...,\n {2},\n {3})".format(
                 population[0],
                 population[1],
                 population[-2],

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,11 @@ pylint==1.4.4
 PyYAML==3.11
 future==0.15.2
 tox==2.1.1
-virtualenv==13.1.2
+virtualenv==12.0.2
 six==1.9.0
 flake8==2.4.1
 watchdog==0.8.3
+unittest2==1.1.0
+nose==1.3.7
+rednose==0.4.3
+python-termstyle==0.1.10

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
 
 test_requirements = [
    'fake-factory',
+   'unittest2',
 ]
 
 setup(

--- a/tests/test_ehrcorral.py
+++ b/tests/test_ehrcorral.py
@@ -10,7 +10,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import unittest
+import unittest2 as unittest
 import json
 import os
 
@@ -40,13 +40,13 @@ class TestHerdProperties(unittest.TestCase):
             herd = Herd()
             str(herd)
         except Exception as e:
-            self.fail("Getting string of empty herd raised: {}.".format(e))
+            self.fail("Getting string of empty herd raised: {0}.".format(e))
         self.assertEqual(str(herd), '()')
         try:
             herd = self.herd
             str(herd)
         except Exception as e:
-            self.fail("Getting string of herd raised: {}.".format(e))
+            self.fail("Getting string of herd raised: {0}.".format(e))
         self.assertNotEqual(str(herd), '()')
 
     def test_retrieving_populated_herd_size(self):
@@ -56,7 +56,7 @@ class TestHerdProperties(unittest.TestCase):
         try:
             herd = Herd()
         except Exception as e:
-            self.fail("Creating herd with no population raised: {}.".format(e))
+            self.fail("Creating herd with no population raised: {0}.".format(e))
         self.assertEqual(herd.size, 0)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,7 @@ commands =
     coverage report
 deps =
     -r{toxinidir}/requirements_dev.txt
+
+[testenv:py26]
+commands =
+    nosetests tests/test_ehrcorral.py


### PR DESCRIPTION
- Mainly required position arguments on str.format()
- Upgraded use of unittest to unittest2 module, and test Python 2.6
with nose rather than unittest so setUpClass works in 2.6