### PR TITLE
Update similarity matrix to account for both empty names

### DIFF
--- a/ehrcorral/measures.py
+++ b/ehrcorral/measures.py
@@ -102,10 +102,14 @@ def get_forename_similarity(herd, records, method, name_type):
         ]
     second_forename = [item[0] for item in second_forefreq]
     second_freq = [item[1] for item in second_forefreq]
-    # if there is no surname for our first record, or both second record
-    # surnames, then we do not need to compare
-    if first_forename == '' or second_forename[0] == second_forename[1] == '':
-        return 0, 6
+    # if there is no forename for our first record, we either dismiss the
+    # similarity if one of the second record forenames is empty, or return a
+    # zero match.
+    if first_forename == '':
+        if second_forename[0] == '' or second_forename[1] == '':
+            return 0, 0
+        else:
+            return 0, 6
     # Get difference between first record name and both second record names,
     # then find the one that has the minimum difference and keep that one
     diffs = [method(first_forename, name) for name in second_forename]
@@ -177,10 +181,14 @@ def get_surname_similarity(herd, records, method, name_type):
         ]
     second_surname = [item[0] for item in second_forefreq]
     second_freq = [item[1] for item in second_forefreq]
-    # if there is no surname for our first record, or both second record
-    # surnames, then we do not need to compare
-    if first_surname == '' or second_surname[0] == second_surname[1] == '':
-        return 0, 12
+    # if there is no surname for our first record, we either dismiss the
+    # similarity if one of the second record surnames is empty, or return a
+    # zero match.
+    if first_surname == '':
+        if second_surname[0] == '' or second_surname[1] == '':
+            return 0, 0
+        else:
+            return 0, 12
     # Get difference between first record name and both second record names,
     # then find the one that has the minimum difference and keep that one
     diffs = [method(first_surname, name) for name in second_surname]


### PR DESCRIPTION
This pull request modifies a conditional in the name similarity functions so that, if both records in the comparison do not have a name, which could either be `birth_surname`, or `mid_forename`, then the comparison is dropped.